### PR TITLE
[GH-4][WIP] read temp sensor from dbus

### DIFF
--- a/br-ext-tree/package/joomby/CMakeLists.txt
+++ b/br-ext-tree/package/joomby/CMakeLists.txt
@@ -30,6 +30,8 @@ set(LIBS
     Qt5::Quick
     Qt5::Gui
     Qt5::Charts
+    systemd
+    sdbusplus
     pthread
     )
 

--- a/br-ext-tree/package/joomby/src/temp_sensor.cpp
+++ b/br-ext-tree/package/joomby/src/temp_sensor.cpp
@@ -9,6 +9,8 @@
 #include <QtGlobal>
 #include <QVariant>
 #include <thread>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/message.hpp>
 
 #include "temp_sensor.h"
 
@@ -91,7 +93,16 @@ QVariant TempSensor::data(const QModelIndex &index, int role) const
  * Assumes that there's a char device driver at `/dev/bme280`
  */
 double TempSensor::read_temperature_sensor() {
-    return (double) (rng.random() % 25);
+    int temp;
+    auto reply = b.call(m);
+    // FIXME: Getting the following runtime error when uncommenting this .read
+    //   ...
+    //   terminate called after throwing an instance of
+    //   'sdbusplus::exception::SdBusError' what():  sd_bus_message_read_basic
+    //   fundamental: System.Error.ENXIO: No such device or address
+    //   ...
+    // reply.read(temp);
+    return (double) temp;
 }
 
 /* Continuously poll temperature sensor

--- a/br-ext-tree/package/joomby/src/temp_sensor.h
+++ b/br-ext-tree/package/joomby/src/temp_sensor.h
@@ -5,6 +5,8 @@
 #include <QList>
 #include <QPointF>
 #include <vector>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/message.hpp>
 
 #include "lib/lib.h"
 
@@ -30,4 +32,10 @@ private:
     void append(const QPointF& point);
     lib::fixed_queue<QPointF, 10> queue;
     lib::urandom rng {};
+    sdbusplus::bus::bus b = sdbusplus::bus::new_user();
+    sdbusplus::message::message m = \
+        b.new_method_call("org.joomby.TemperatureSensor",
+                          "/org/joomby/TemperatureSensor",
+                          "org.joomby.TemperatureSensor",
+                          "Read");
 };


### PR DESCRIPTION
The following is still WIP

Getting the following runtime error when uncommenting this `reply.read(temp)`
```
terminate called after throwing an instance of 'sdbusplus::exception::SdBusError'
what():  sd_bus_message_read_basic fundamental: System.Error.ENXIO: No such device or address
```
from the docs:
```
-ENXIO
    The message does not contain the specified type at current position. 
```

Still need to update the server interface to return an array of the values in the registers of the bme280 (currently its set to int64)